### PR TITLE
Use unique id for the elevation element which will allow multiple blocks to show the elevation graph.

### DIFF
--- a/graphs.php
+++ b/graphs.php
@@ -32,7 +32,7 @@ function yft_showfitfile_block_altitudegraph($attr) {
     $polyline = rtrim($polyline, ",");
 	$polyline = "[" . $polyline . "]";
 
-	$html = "const ctx = document.getElementById('altitude');
+	$html = "const ctx = document.getElementById('altitude-" . $attr['mapID'] . "');
 	var latData = " . yft_showfitfile_block_latitude_data($attr) . ";
  	var longData = " . yft_showfitfile_block_longitude_data($attr) . ";
  	var circle = new L.circleMarker();

--- a/showfitfile.php
+++ b/showfitfile.php
@@ -116,8 +116,8 @@ function yft_showfitfile_block_summary_table($attr) {
 	}
 }
 
-function yft_showfitfile_block_canvas_for_altitude_graph() {
-	return yft_showfitfile_block_canvas_for_graph("altitude");
+function yft_showfitfile_block_canvas_for_altitude_graph($mapID) {
+	return yft_showfitfile_block_canvas_for_graph("altitude-" . $mapID);
 }
 
 function yft_showfitfile_block_canvas_for_graph($canvasID) {
@@ -161,7 +161,7 @@ function yft_showfitfile_block_longitude_data($attr) {
 }
 
 
-function yft_showfitfile_block_map($attr) {
+function yft_showfitfile_block_map(&$attr) {
 	global $startPoint;
 	global $endPoint;
 	$lineColour = $attr['lineColour'];
@@ -172,7 +172,8 @@ function yft_showfitfile_block_map($attr) {
 	
 	if ($attr['showAltitudeGraph']) {
 		// Add the canvas for the altitude graph
-		$maphtml .= yft_showfitfile_block_canvas_for_altitude_graph();
+		$attr['mapID'] = $mapID;
+		$maphtml .= yft_showfitfile_block_canvas_for_altitude_graph($mapID);
 	}
 
 

--- a/src/block.json
+++ b/src/block.json
@@ -119,6 +119,10 @@
 			"type": "string",
 			"default": "-"
 		},
+		"mapID": {
+			"type": "string",
+			"default": ""
+		},
 		"ascent": {
 			"type": "integer",
 			"default": 0


### PR DESCRIPTION
Prior to this PR attempting to insert multiple logs on a single page would result in the second and subsequent elevation blocks to appear blank.
Using a unique element id for the elevation element allows multiple logs to display correctly.
Fixes #11 